### PR TITLE
Make dev server connection work for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="false"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Clear text traffic got disabled by default in SDK 28 and therefore no connection could be made to the dev server. We can use this to test the Android emulator until we find a better approach.

Let's not merge this but keep the PR open.