### PR TITLE
Remove loading indicator from home screen

### DIFF
--- a/src/router/logged-in/screens/HomeScreen.js
+++ b/src/router/logged-in/screens/HomeScreen.js
@@ -21,7 +21,6 @@ import { resetStack } from '../../../utils/navigation';
 import { Vertical } from '../../../components/ui/Spacer';
 import messaging from '@react-native-firebase/messaging';
 import Footer from '../../../components/Footer';
-import LoadingScreen from '../../../components/LoadingScreen';
 import { AuthenticationError } from '../../../api/ApiClient';
 
 const links = {


### PR DESCRIPTION
It can load in the background, not showing when opening push notifications anyways.

Avoids flickering of home screen when loading is shown for a very short time.