### PR TITLE
Fix Android 28 debug issue

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -125,7 +125,12 @@ android {
         }
     }
     buildTypes {
+        debug {
+            manifestPlaceholders = [isDebug:true]
+        }
+
         release {
+            manifestPlaceholders = [isDebug:false]
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="false"
+        android:usesCleartextTraffic="${isDebug}"
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
In development, the app fetches the JS bundle from the bundler over
http. Since Android 28, all app requests should go through https.

This commit removes that requirement only for debug builds.

Replaces #11 