### PR TITLE
Switch to activity provider on Android

### DIFF
--- a/src/tracking.js
+++ b/src/tracking.js
@@ -41,7 +41,7 @@ function getConfiguration(title, text) {
       locationProvider: BackgroundGeolocation.ACTIVITY_PROVIDER,
 
       // How often to check the current activity.
-      activitiesInterval: 1000 * 30,
+      activitiesInterval: 1000 * 90,
 
       // Only Android: The minimum time interval between location updates when not stationary.
       // - iOS ignores this and only posts location updates based on the `distanceFilter` above.

--- a/src/tracking.js
+++ b/src/tracking.js
@@ -1,7 +1,7 @@
 import * as Permissions from 'expo-permissions';
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
 
-function getConfiguration() {
+function getConfiguration(title, text) {
   const configuration = {
     // Accept a 100 meter accuracy.
     desiredAccuracy: BackgroundGeolocation.MEDIUM_ACCURACY,
@@ -63,7 +63,7 @@ async function startBackgroundTracking(title, text) {
   try {
     await stopBackgroundTracking();
 
-    BackgroundGeolocation.configure(getConfiguration());
+    BackgroundGeolocation.configure(getConfiguration(title, text));
     BackgroundGeolocation.start();
 
     return true;


### PR DESCRIPTION
This provider disables geolocation updates when the user is determined to be stationary.

This kind of activity checking is supposed to require less battery than polling the GPS, but we should do more testing to be sure.

Fixes #33 (hopefully)